### PR TITLE
(ver 1.8.1) 팀 생성 및 관리 페이지 추가

### DIFF
--- a/src/main/resources/static/css/m-team-setting.css
+++ b/src/main/resources/static/css/m-team-setting.css
@@ -1,0 +1,26 @@
+@media (max-width: 600px) {
+    .wrap {
+        margin-top: 5vh;
+        padding: 0 10px;
+    }
+    .member_profile > form > .article {
+        height: 120px;
+        position: relative;
+    }
+    .btns {
+        right: 10px;
+        bottom: 10px;
+        display: flex;
+        position: absolute;
+        justify-content: center;
+    }
+
+    .modal_wrap {
+        width: 70vw;
+    }
+
+    #team_name {
+        width: 160px;
+        overflow-x: scroll;
+    }
+}

--- a/src/main/resources/static/css/mypage.css
+++ b/src/main/resources/static/css/mypage.css
@@ -30,15 +30,22 @@ div[class*="Box"] {
 
 *[class*="Profile"] {
   width: 100%;
-
   padding: 10px 15px;
   background: yellow;
   display: flex;
-  flex-wrap: wrap;
   position: relative;
 }
 .teamProfile {
   margin-bottom: 10px;
+}
+
+.addTeam {
+  width: 100%;
+  height: 50px;
+  line-height: 50px;
+  font-weight: bold;
+  border: 1px solid red;
+  text-align: center;
 }
 
 img[class*="Img"] {

--- a/src/main/resources/static/css/team-add.css
+++ b/src/main/resources/static/css/team-add.css
@@ -1,0 +1,37 @@
+.wrap {
+    width: 100vw;
+    height: 100vh;
+    margin-top: 20vh;
+    border: 1px dashed #000;
+    text-align: center;
+}
+
+.title {
+    margin: 40px 0px;
+    text-align: center;
+}
+
+.inputName {
+    width: 300px;
+    height: 40px;
+    margin: 0 auto;
+    margin-bottom: 30px;
+    border-radius: 10px;
+    display: block;
+}
+
+.sucess {
+    width: 150px;
+    height: 40px;
+    margin-bottom: 30px;
+    border-radius: 20px;
+    background: #000;
+    color: white;
+    border: none;
+}
+
+@media (max-width: 600px) {
+    .wrap {
+        margin-top: 10vh;
+    }
+}

--- a/src/main/resources/static/css/team-setting.css
+++ b/src/main/resources/static/css/team-setting.css
@@ -1,0 +1,170 @@
+body {
+    overflow: hidden;
+}
+
+.wrap {
+    width: 100vw;
+    height: 100vh;
+    margin-top: 10vh;
+    border: 1px dashed #000;
+    z-index: 0;
+}
+
+.title {
+    margin: 40px 0px;
+    text-align: center;
+}
+
+.content_wrap {
+    margin: 0 auto;
+    width: 100%;
+    max-width: 800px;
+    min-width: 360px;
+    border: 1px dashed red;
+}
+
+div[class*="_profile"] {
+    width: 100%;
+    border: 1px solid #000;
+}
+.team_profile {
+    height: 110px;
+}
+
+.member_profile {
+    margin-top: 20px;
+}
+
+.sub_title {
+    padding-left: 10px;
+    height: 30px;
+    line-height: 30px;
+}
+
+.article {
+    width: 100%;
+    height: 80px;
+    padding: 10px;
+    margin-bottom: 10px;
+    border: 1px solid magenta;
+    display: flex;
+    position: relative;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.profileImg {
+    width: 60px;
+    height: 60px;
+    margin-right: 10px;
+    border-radius: 50%;
+    border: 1px solid #000;
+    display: inline-block;
+}
+
+.input_text {
+    font-size: 1.2rem;
+    font-weight: bold;
+    background: transparent;
+    border: 1px solid #000;
+}
+
+.meta_data {
+    height: 100%;
+    justify-items: center;
+    display: flex;
+    flex-direction: row;
+}
+
+.texts {
+    margin-top: 5px;
+    margin-right: 20px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+button[class*="_btn"] {
+    width: 70px;
+    height: 30px;
+    margin-left: 5px;
+    border-radius: 15px;
+    border: 1px solid #000;
+}
+
+#edit_team {
+    top: 30%;
+    right: 85px;
+    position: absolute;
+}
+
+#change_team {
+    top: 30%;
+    right: 10px;
+    position: absolute;
+}
+
+
+.modal {
+    top: 0%;
+    left: 0%;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    position: absolute;
+    border: 1px solid #000;
+    background: rgba(0, 0, 0, 0.2);
+    backdrop-filter: blur(5px);
+    display: none;
+}
+
+/* modal 창을 띄운 뒤에는 body 의 overflow 속성을 hidden 으로 잡아야함  */
+
+.modal_wrap {
+    margin: 0 auto;
+    margin-top: 25vh;
+    padding: 20px;
+    width: 400px;
+    height: 320px;
+    border-radius: 15px;
+    background: #fff;
+    text-align: center;
+    box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.3);
+    position: relative;
+}
+
+.modal_wrap h3 {
+    margin-top: 15px;
+    margin-bottom: 30px;
+    font-weight: bold;
+}
+
+.modal_wrap button {
+    width: 100px;
+    height: 30px;
+    border-radius: 15px;
+    display: block;
+    margin: 0 auto;
+    border: 1px solid #000;
+    margin-bottom: 10px;
+    font-weight: normal;
+}
+
+.modal_wrap button:hover {
+    font-weight: bold;
+}
+
+#go_back {
+    position: absolute;
+    bottom: 0px;
+    right: 0px;
+    border-radius: 0;
+    border: none;
+    background: transparent;
+}
+
+.btns {
+    border: 1px solid #000;
+    display: flex;
+    align-items: center;
+}

--- a/src/main/resources/static/js/jQeuryCheck.js
+++ b/src/main/resources/static/js/jQeuryCheck.js
@@ -1,0 +1,10 @@
+// jQuery 존재하는지 판단하여 없으면 스크립트 CDN 삽입
+if (typeof jQuery == "undefined") {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src = "https://code.jquery.com/jquery-3.6.1.min.js";
+    document.getElementsByTagName("head")[0].appendChild(script);
+} else {
+    // jQuery 가 이미 존재하면 출력
+    console.log("jQuery Ready");
+}

--- a/src/main/resources/templates/admin-main.html
+++ b/src/main/resources/templates/admin-main.html
@@ -13,6 +13,7 @@
             integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
             crossorigin="anonymous"
     ></script>
+    <script src="/static/js/jQeuryCheck.js"></script>
 </head>
 <body>
 <div class="moblieView">

--- a/src/main/resources/templates/admin-news.html
+++ b/src/main/resources/templates/admin-news.html
@@ -13,6 +13,7 @@
             integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
             crossorigin="anonymous"
     ></script>
+    <script src="/static/js/jQeuryCheck.js"></script>
 </head>
 <body>
 <div class="moblieView">

--- a/src/main/resources/templates/admin-qna.html
+++ b/src/main/resources/templates/admin-qna.html
@@ -13,6 +13,7 @@
             integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
             crossorigin="anonymous"
     ></script>
+    <script src="/static/js/jQeuryCheck.js"></script>
 </head>
 <body>
 <div class="moblieView">

--- a/src/main/resources/templates/calendar.html
+++ b/src/main/resources/templates/calendar.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>캘린더</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>당신의 동료, 영원한 친구 buddy</title>
     <script src="https://code.jquery.com/jquery-3.6.1.min.js"></script>
+    <link rel="stylesheet" href="/static/css/reset.css">
     <link rel="stylesheet" href="/static/css/home.css" />
     <link rel="stylesheet" href="/static/css/mypage.css" />
     <link rel="stylesheet" href="/static/css/m-home.css" />
@@ -106,6 +107,12 @@
           <button type="button" id="goTeam" class="floatBtn">
             <a href="">팀으로 가기</a>
           </button>
+        </div>
+
+        <div class="addTeam">
+          <a href="">
+            팀 생성 하기
+          </a>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="/static/css/mypage.css" />
     <link rel="stylesheet" href="/static/css/m-home.css" />
     <link rel="stylesheet" href="/static/css/m-mypage.css" />
+    <script src="/static/js/jQeuryCheck.js"></script>
   </head>
   <body>
   <th:block th:if="${#strings. isEmpty(session.memberSeq)}">

--- a/src/main/resources/templates/myprofile.html
+++ b/src/main/resources/templates/myprofile.html
@@ -13,6 +13,7 @@
           integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
           crossorigin="anonymous"
   ></script>
+  <script src="/static/js/jQeuryCheck.js"></script>
 </head>
 <body>
 <div class="wrap">

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+    <script src="/static/js/jQeuryCheck.js"></script>
   </head>
   <body>
     <div class="wrap">

--- a/src/main/resources/templates/team-add.html
+++ b/src/main/resources/templates/team-add.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>팀 생성하기</title>
+  <link rel="stylesheet" href="/static/css/reset.css" />
+  <link rel="stylesheet" href="/static/css/team-add.css" />
+  <script src="/static/js/jQeuryCheck.js"></script>
+</head>
+<body>
+<div class="wrap">
+  <h1 class="title">팀 생성</h1>
+  <form action="">
+    <input type="text" name="teamName" id="teamName" class="inputName" />
+    <button type="submit" class="sucess">완료</button>
+  </form>
+  <p class="cancel">
+    팀 생성을 취소할까요? <a href=""><strong>취소</strong></a>
+  </p>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/team-setting.html
+++ b/src/main/resources/templates/team-setting.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>팀 관리</title>
+  <link rel="stylesheet" href="/static/css/reset.css" />
+  <link rel="stylesheet" href="/static/css/team-setting.css" />
+  <link rel="stylesheet" href="/static/css/m-team-setting.css" />
+  <script
+          src="https://code.jquery.com/jquery-3.6.1.min.js"
+          integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
+          crossorigin="anonymous"
+  ></script>
+  <script src="/static/js/jQeuryCheck.js"></script>
+</head>
+<body>
+<div class="wrap">
+  <h1 class="title">팀 관리</h1>
+  <div class="content_wrap">
+    <div class="team_profile">
+      <p class="sub_title">팀 프로필</p>
+      <form action="">
+        <div class="article">
+          <input
+                  type="text"
+                  name="team_name"
+                  id="team_name"
+                  class="input_text"
+                  value="팀 이름"
+          />
+          <button type="submit" id="change_team" class="edit_btn">
+            변경
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <div class="member_profile">
+      <p class="sub_title">멤버 관리</p>
+      <form action="">
+        <div class="article">
+          <div class="meta_data">
+            <img src="" alt="" class="profileImg" />
+            <div class="texts">
+              <input
+                      type="text"
+                      name="member_name"
+                      id="member_name"
+                      class="input_text"
+                      value="이름"
+                      readonly
+              />
+              <input
+                      type="text"
+                      name="member_email"
+                      id="member_email"
+                      class="input_email"
+                      value="이메일"
+                      readonly
+              />
+            </div>
+          </div>
+          <div class="btns">
+            <button
+                    type="button"
+                    name="grade"
+                    id="grade"
+                    class="grade_btn"
+                    onclick="opener()"
+            >
+              등급
+            </button>
+            <button type="submit" class="edit_btn" id="eidt_member">
+              변경
+            </button>
+            <button type="submit" class="del_btn" id="del_member">
+              강퇴
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="modal">
+    <div class="modal_wrap">
+      <h1>🤔</h1>
+      <h3>
+        member 님의 등급을 <br />
+        어떻게 변경할까요?
+      </h3>
+      <button id="master" class="modal_btn" onclick="changer(this)">
+        마스터
+      </button>
+      <button id="manager" class="modal_btn" onclick="changer(this)">
+        매니저
+      </button>
+      <button
+              id="staff"
+              type="button"
+              class="modal_btn"
+              onclick="changer(this)"
+      >
+        팀원
+      </button>
+      <button id="go_back" type="button" onclick="closer()">나가기</button>
+    </div>
+  </div>
+
+  <p style="text-align: center; margin-top: 20px;">팀을 삭제하시겠습니까? <a href="" id="del_team"><strong>삭제</strong></a></p>
+</div>
+<script>
+  var modal = document.querySelector(".modal");
+  var grade = document.querySelector("#grade");
+  var gradeBtn = document.querySelector(".grade_btn");
+  var modalBtn = document.querySelectorAll(".modal_btn");
+  var master = document.querySelector("#master");
+  var manager = document.querySelector("#manager");
+  var staff = document.querySelector("#staff");
+  var choice = $(".staff").html();
+  // modal 열림 함수
+  function closer() {
+    modal.style.display = "none";
+  }
+  // modal 닫힘 함수
+  function opener() {
+    modal.style.display = "block";
+  }
+  // 등급 선택시 이벤트 행동
+  function changer(e) {
+    grade.innerText = e.innerText;
+    modal.style.display = "none";
+  }
+ // 팀 삭제 시 경고메세지
+  $("#del_team").click( function (){
+    var result = confirm("팀을 정말 삭제 하시겠습니까?");
+    if(result) {
+      alert("팀이 삭제 되었습니다")
+    }
+    else {
+      alert("잘 생각하셨어요!")
+    }
+  })
+
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/team.html
+++ b/src/main/resources/templates/team.html
@@ -13,6 +13,7 @@
           integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
           crossorigin="anonymous"
   ></script>
+  <script src="/static/js/jQeuryCheck.js"></script>
 </head>
 <body>
 <div class="wrap">

--- a/src/main/resources/templates/testInvite.html
+++ b/src/main/resources/templates/testInvite.html
@@ -8,6 +8,7 @@
             integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ="
             crossorigin="anonymous"
     ></script>
+    <script src="/static/js/jQeuryCheck.js"></script>
 </head>
 <body>
 회원초대 테스트 페이지 입니다.<br>

--- a/src/main/resources/templates/testInviteConfirm.html
+++ b/src/main/resources/templates/testInviteConfirm.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+    <script src="/static/js/jQeuryCheck.js"></script>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
ver 1.8.1 패치노트

1. team-add 
팀을 새로 생성하는 페이지 입니다.

2. team-setting
팀 관리 메뉴입니다. 
- 멤버 들의 등급관리 및, 강제퇴장 
- 팀의 이름 변경, 팀의 삭제

3. jQuery Import Checked JS
간혹가다 제이쿼리 cdn 이 제대로 import 되지 않거나, 오류가 발생 시 방지하는 JS 입니다.
html 생성시 기본으로 생성해놓는 방향이 좋을 듯 합니다.

- ps.
3 번 같은 경우, 자바스크립트로 테스트를 진행하다가 구글링 해서 발견한 부분입니다.
유용할듯 싶어 추가 했는데, 팀원들 의견에 따라 과반이 필요성을 느끼지 못한다면
곧바로 삭제 하겠습니다.

by 팀원 정택구
22-12-17
